### PR TITLE
Implemented changes for issue #46

### DIFF
--- a/gui/documentationbrowser.cpp
+++ b/gui/documentationbrowser.cpp
@@ -299,7 +299,7 @@ bool DocumentationBrowser::createNewPage(const wxString& docId)
     viewer->SetRelatedFrame(this, m_titleTemplate);
     viewer->SetRelatedStatusBar(0);
 
-    m_docTabs->AddPage(viewer, docId, true);
+    m_docTabs->AddPage(viewer, "Loading ...", true);
     return viewer->ShowPageOnItem(docId);
 }
 


### PR DESCRIPTION
Implements necessary changes for #46. Closes #46

Proposed changes:

- Changed the initial tab title to `"Loading ..."` as described within #46 

@numere-org/maintainers
