### PR TITLE
49 glitch toolbar too wide in graphviewer

### DIFF
--- a/changes.tmp
+++ b/changes.tmp
@@ -1,1 +1,2 @@
 Fixed	The documentation browser can now be opened again using "help window" and similar. The necessary time for opening up with this method was greatly reduced.
+Fixed	The graph window cannot made smaller than a defined minimal size anymore. The visual glitch cutting off parts of the the style text input has been resolved.

--- a/gui/wx.cpp
+++ b/gui/wx.cpp
@@ -173,6 +173,10 @@ wxMGL::wxMGL(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& 
         statusbar = m_parentFrame->CreateStatusBar(3);
         int nWidths[] = {-2,-1,-1};
         statusbar->SetFieldsCount(3, nWidths);
+
+        // Define the minimal possible client size, below which any resizing
+        // action is prohibited.
+        m_parentFrame->SetMinClientSize(wxSize(550,100));
     }
     else
         m_parentFrame = nullptr;
@@ -276,6 +280,7 @@ void wxMGL::InitializeToolbar()
     toptoolbar->AddTool(ID_GRAPH_CIRCLE, _guilang.get("GUI_GRAPH_CIRCLE"),  app->getToolbarIcon("add-circ"), _guilang.get("GUI_GRAPH_CIRCLE"), wxITEM_CHECK);
     toptoolbar->AddTool(ID_GRAPH_TEXT, _guilang.get("GUI_GRAPH_TEXT"), app->getToolbarIcon("add-text"), _guilang.get("GUI_GRAPH_TEXT"), wxITEM_CHECK);
 
+    // Create a narrow text ctrl to insert the styling information
     styling = new wxTextCtrl(toptoolbar, wxID_ANY, "B-__", wxDefaultPosition, wxSize(60,-1));
 
     toptoolbar->AddControl(styling, "STYLE");

--- a/gui/wx.cpp
+++ b/gui/wx.cpp
@@ -276,7 +276,7 @@ void wxMGL::InitializeToolbar()
     toptoolbar->AddTool(ID_GRAPH_CIRCLE, _guilang.get("GUI_GRAPH_CIRCLE"),  app->getToolbarIcon("add-circ"), _guilang.get("GUI_GRAPH_CIRCLE"), wxITEM_CHECK);
     toptoolbar->AddTool(ID_GRAPH_TEXT, _guilang.get("GUI_GRAPH_TEXT"), app->getToolbarIcon("add-text"), _guilang.get("GUI_GRAPH_TEXT"), wxITEM_CHECK);
 
-    styling = new wxTextCtrl(toptoolbar, wxID_ANY, "B-__");
+    styling = new wxTextCtrl(toptoolbar, wxID_ANY, "B-__", wxDefaultPosition, wxSize(60,-1));
 
     toptoolbar->AddControl(styling, "STYLE");
     toptoolbar->Realize();


### PR DESCRIPTION
### SUMMARY
Implements necessary changes for #49 

*Reviewers:* @numere-org/maintainers

### IMPLEMENTATION
* Implementation: Made the styling text input less wide and set a minimal client size for the grapher window
* Implementation test: Used `plot sin(x) -set aspect=ASPECT` with different `ASPECT` less than 1 or greater than 2

### DOCUMENTATION
* [x] ChangesLog updated
* [x] Code changes commented
* **Documentation articles:**
    * [ ] corresponding documentation articles updated
    * [ ] new documentation articles created
    * [x] not needed
* **Language files:**
    * [ ] corresponding language files updated
    * [x] not needed

----------------

### TESTS BY REVIEWERS
* [ ] Added to the automatic SW tests
* [ ] Tested manually

