### PR TITLE
58 string expressions cannot be used as indices

### DIFF
--- a/changes.tmp
+++ b/changes.tmp
@@ -1,1 +1,2 @@
 Fixed	The documentation browser can now be opened again using "help window" and similar. The necessary time for opening up with this method was greatly reduced.
+Fixed	Using string expressions as indices is possible again.

--- a/kernel/core/strings/stringparser.cpp
+++ b/kernel/core/strings/stringparser.cpp
@@ -1535,9 +1535,21 @@ namespace NumeRe
                          || sExpr[i] == '>')
                 {
                     if (sExpr[i] == ':' && hasIf <= 0)
+                    {
+                        if (i+1 == sExpr.length())
+                            throw SyntaxError(SyntaxError::STRING_ERROR, sExpr.get_viewed_string(),
+                                              i+sExpr.get_offset(), _lang.get("ERR_NR_3603_MISSING_OPERAND"));
+
                         continue;
+                    }
                     else if (sExpr[i] == ',' && hasIf > 0)
+                    {
+                        if (i+1 == sExpr.length())
+                            throw SyntaxError(SyntaxError::STRING_ERROR, sExpr.get_viewed_string(),
+                                              i+sExpr.get_offset(), _lang.get("ERR_NR_3603_MISSING_OPERAND"));
+
                         continue;
+                    }
                     else if (sExpr[i] == ':')
                         hasIf--;
                     else if (sExpr[i] == '?')


### PR DESCRIPTION
### SUMMARY
Implements necessary changes for #58 

*Reviewers:* @numere-org/maintainers

### IMPLEMENTATION
* Implementation: Added new error codes for missing operands (which was the root cause for the endless loop) and only inserted single index expressions into the stirng parser
* Implementation test: Executed erroneous code without problems and ran the string tests. All problems were resolved. Here's a simple code snippet to check, whether the problem has been resolved:

```
par{} = getfileinfo("<>/numere.exe");
c{} = {1:16};
partable(1, 1+num(par{})/2:) = par{{2:2:nlen}};
```

### DOCUMENTATION
* [ ] ChangesLog updated
* [ ] Code changes commented
* **Documentation articles:**
    * [ ] corresponding documentation articles updated
    * [ ] new documentation articles created
    * [ ] not needed
* **Language files:**
    * [ ] corresponding language files updated
    * [ ] not needed

----------------

### TESTS BY REVIEWERS
* [ ] Added to the automatic SW tests
* [ ] Tested manually

