### PR TITLE
Implements changes required by #19

### DIFF
--- a/changes.tmp
+++ b/changes.tmp
@@ -4,3 +4,4 @@ Fixed	The graph window cannot made smaller than a defined minimal size anymore. 
 Fixed	Excel sheets with more than a single table headline are readable again.
 Fixed	Drag/drop of files into the editor is now working as expected.
 Fixed	"dialog" now accept also tables as input sources for their default values.
+New	The new flow control command "leave" allows jumping out of nested loops completely without the need of unnecessary complex "if-else" checks and boolean flags.

--- a/gui/editor/codeanalyzer.cpp
+++ b/gui/editor/codeanalyzer.cpp
@@ -458,6 +458,7 @@ AnnotationCount CodeAnalyzer::analyseCommands()
     if (sSyntaxElement != "hline"
             && sSyntaxElement != "continue"
             && sSyntaxElement != "break"
+            && sSyntaxElement != "leave"
             && sSyntaxElement != "separator"
             && sSyntaxElement != "else"
             && m_editor->isBlockEnd(sSyntaxElement) == wxNOT_FOUND
@@ -698,7 +699,11 @@ AnnotationCount CodeAnalyzer::analyseCommands()
                     if (!vMatches.size())
                         vMatches = m_editor->m_search->FindAll("return", wxSTC_NSCR_COMMAND, wordend, vBlock[i+1], false);
 
-                    // Ensure that there's one "break" or "return"
+                    // Search also for "leave"s as an alternative
+                    if (!vMatches.size())
+                        vMatches = m_editor->m_search->FindAll("leave", wxSTC_NSCR_COMMAND, wordend, vBlock[i+1], false);
+
+                    // Ensure that there's one "break", "leave" or "return"
                     // statement
                     if (m_options->GetAnalyzerOption(Options::SWITCH_FALLTHROUGH) && !vMatches.size())
                     {

--- a/kernel/core/commandfunctions.hpp
+++ b/kernel/core/commandfunctions.hpp
@@ -5375,6 +5375,9 @@ static std::map<std::string,CommandFunc> getCommandFunctions()
     mCommandFuncMap["endlayout"] = cmd_context_specific;
     mCommandFuncMap["group"] = cmd_context_specific;
     mCommandFuncMap["endgroup"] = cmd_context_specific;
+    mCommandFuncMap["break"] = cmd_context_specific;
+    mCommandFuncMap["continue"] = cmd_context_specific;
+    mCommandFuncMap["leave"] = cmd_context_specific;
     mCommandFuncMap["else"] = cmd_context_specific;
     mCommandFuncMap["elseif"] = cmd_context_specific;
     mCommandFuncMap["endif"] = cmd_context_specific;


### PR DESCRIPTION
### SUMMARY
Implements necessary changes for #19 

*Reviewers:* @numere-org/maintainers

### IMPLEMENTATION
* Implementation: Created the `leave` command as described by the issue analysis. Registered the command also as context-specific.
* Implementation test: Created a nested loop structure with a counter and used `leave` to jump out of both loops at the same time.

### DOCUMENTATION
* [x] ChangesLog updated
* [x] Code changes commented
* **Documentation articles:**
    * [x] corresponding documentation articles updated
    * [ ] new documentation articles created
    * [ ] not needed
* **Language files:**
    * [x] corresponding language files updated
    * [ ] not needed

----------------

### TESTS BY REVIEWERS
* [ ] Added to the automatic SW tests
* [x] Tested manually

