### PR TITLE
Implemented changes required by #52

### DIFF
--- a/changes.tmp
+++ b/changes.tmp
@@ -8,3 +8,4 @@ Fixed	Empty cells are now preserved, if one converts string columns to logical c
 Fixed	The default value of "getkeyval()" now works as intended.
 Added	It's now possible to define an enumeration using the syntax "declare enum -> {VAL1, VAL2, ..}"
 Fixed	Issue in dependency viewer, when clicking at empty space, is now fixed
+Fixed	Using "Go to procedure" works now also with external procedures.

--- a/gui/NumeReWindow.cpp
+++ b/gui/NumeReWindow.cpp
@@ -3122,8 +3122,8 @@ void NumeReWindow::NewFile(FileFilterType _filetype, const wxString& defaultfile
     }
     else
     {
-        wxString filename;
-        wxString folder;
+        std::string filename;
+        std::string folder;
         wxTextEntryDialog* textentry;
 
         // If no default file name was passed, ask
@@ -3152,63 +3152,39 @@ void NumeReWindow::NewFile(FileFilterType _filetype, const wxString& defaultfile
             delete textentry;
         }
         else
-            filename = defaultfilename;
+            filename = defaultfilename.ToStdString();
 
         // Remove the dollar sign, if there is one
         if (filename.find('$') != std::string::npos)
             filename.erase(filename.find('$'),1);
 
-        // Remove the path parts from the file name
-        // These are either the tilde, the slash or the
-        // backslash
-        if (filename.find('~') != std::string::npos)
-        {
-            folder = filename.substr(0, filename.rfind('~')+1);
-            filename.erase(0, filename.rfind('~')+1);
-        }
+        // Replace all separators to UNIX separators
+        replaceAll(filename, "~", "/");
+        replaceAll(filename, "\\", "/");
 
+        // Remove the path parts from the file name
         if (filename.find('/') != std::string::npos)
         {
-            if (folder.length())
-                folder += "/" + filename.substr(0, filename.rfind('/')+1);
-            else
-                folder = filename.substr(0, filename.rfind('/')+1);
-
+            folder = filename.substr(0, filename.rfind('/')+1);
             filename.erase(0, filename.rfind('/')+1);
         }
 
-        if (filename.find('\\') != std::string::npos)
-        {
-            if (folder.length())
-                folder += "/" + filename.substr(0, filename.rfind('\\')+1);
-            else
-                folder = filename.substr(0, filename.rfind('\\')+1);
+        std::vector<std::string> vPaths = m_terminal->getPathSettings();
+        bool isExternal = folder.substr(0, vPaths[PROCPATH].length()) != vPaths[PROCPATH];
 
-            filename.erase(0, filename.rfind('\\')+1);
-        }
-
-        // Replace all path separators
-        if (folder.length())
-        {
-            while (folder.find('~') != std::string::npos)
-                folder[folder.find('~')] = '\\';
-            while (folder.find('/') != std::string::npos)
-                folder[folder.find('/')] = '\\';
-        }
-
-        if (folder == "main\\" && _filetype == FILE_NPRC)
+        if (folder == "main/" && _filetype == FILE_NPRC)
             folder.clear();
-        else
-            folder.insert(0,"\\");
+        else if (!isExternal)
+            folder.insert(0, "/");
 
         // Clean the file and folder names for procedures -
-        // we only allow alphanumeric characters
-        if (_filetype == FILE_NPRC)
+        // we only allow alphanumeric characters in non-external procedures
+        if (_filetype == FILE_NPRC && !isExternal)
         {
-            // Clean the folders
-            for (size_t i = 0; i < folder.length(); i++)
+            // Clean the folders after the root path
+            for (size_t i = vPaths[PROCPATH].length(); i < folder.length(); i++)
             {
-                if (!isalnum(folder[i]) && folder[i] != '_' && folder[i] != '\\' && folder[i] != ':')
+                if (!isalnum(folder[i]) && folder[i] != '_' && folder[i] != '/' && folder[i] != ':')
                     folder[i] = '_';
             }
 
@@ -3255,8 +3231,6 @@ void NumeReWindow::NewFile(FileFilterType _filetype, const wxString& defaultfile
         else if (_filetype == FILE_NPRC)
             filename += ".nprc";
 
-        std::vector<std::string> vPaths = m_terminal->getPathSettings();
-
         m_fileNum += 1;
 
         // Create a new editor
@@ -3269,7 +3243,7 @@ void NumeReWindow::NewFile(FileFilterType _filetype, const wxString& defaultfile
         if (_filetype == FILE_NSCR || _filetype == FILE_PLUGIN || _filetype == FILE_NLYT)
             edit->SetFilename(wxFileName(vPaths[SCRIPTPATH] + folder, filename), false);
         else if (_filetype == FILE_NPRC)
-            edit->SetFilename(wxFileName(vPaths[PROCPATH] + folder, filename), false);
+            edit->SetFilename(isExternal ? wxFileName(folder, filename) : wxFileName(vPaths[PROCPATH] + folder, filename), false);
         else
             edit->SetFilename(wxFileName(vPaths[SAVEPATH] + folder, filename), false);
 

--- a/gui/editor/editor.cpp
+++ b/gui/editor/editor.cpp
@@ -5430,21 +5430,35 @@ void NumeReEditor::FindAndOpenProcedure(const wxString& procedurename)
     vector<std::string> vPaths = m_terminal->getPathSettings();
     wxString pathname = procedurename;
 
-    // Validate the procedure name for unwanted characters
-    for (size_t i = 0; i < pathname.length(); i++)
+    // check whether the procedure is an external procedure
+    if (pathname.substr(0, 2) == "$'" && pathname[pathname.length()-1] == '\'')
     {
-        if (!isalnum(pathname[i])
-            && pathname[i] != '$'
-            && pathname[i] != '/'
-            && pathname[i] != ':'
-            && pathname[i] != '_'
-            && pathname[i] != '\''
-            && pathname[i] != '~')
+        if (!fileExists(pathname.substr(2, pathname.length()-3).ToStdString() + ".nprc"))
         {
-            wxMessageBox(_guilang.get("GUI_DLG_PROC_INVALIDCHARS", procedurename.ToStdString()), _guilang.get("GUI_DLG_PROC_INVALIDCHARS_HEADLINE"), wxCENTER | wxICON_ERROR | wxOK, this);
+            int ret = wxMessageBox(_guilang.get("GUI_DLG_PROC_NEXISTS_CREATE", procedurename.ToStdString()), _guilang.get("GUI_DLG_PROC_NEXISTS_CREATE_HEADLINE"), wxCENTER | wxICON_WARNING | wxYES_NO, this);
+
+            if (ret == wxYES)
+                m_mainFrame->NewFile(FILE_NPRC, pathname.substr(2, pathname.length()-3));
+
             return;
         }
     }
+    else
+    {
+        // Validate the procedure name for unwanted characters
+        for (size_t i = 0; i < pathname.length(); i++)
+        {
+            if (!isalnum(pathname[i])
+                && pathname[i] != '$'
+                && pathname[i] != '_'
+                && pathname[i] != '~')
+            {
+                wxMessageBox(_guilang.get("GUI_DLG_PROC_INVALIDCHARS", procedurename.ToStdString()), _guilang.get("GUI_DLG_PROC_INVALIDCHARS_HEADLINE"), wxCENTER | wxICON_ERROR | wxOK, this);
+                return;
+            }
+        }
+    }
+
 
     // Resolve the namespaces
     if (pathname.find("$this~") != string::npos)


### PR DESCRIPTION
### SUMMARY
Implements necessary changes for #52 

*Reviewers:* @numere-org/maintainers

### IMPLEMENTATION
* Implementation: Added the check in `editor.cpp` and resolved another bug in `NumeReWindow.cpp`, where external procedures and root paths were also checked erroneously
* Implementation test: Referenced internal, external and external sub-procedures and used the goto-procedure feature. Also changed the names to non-existent ones and let the editor create the necessary files by itself (which worked).

### DOCUMENTATION
* [x] ChangesLog updated
* [x] Code changes commented
* **Documentation articles:**
    * [ ] corresponding documentation articles updated
    * [ ] new documentation articles created
    * [x] not needed
* **Language files:**
    * [ ] corresponding language files updated
    * [x] not needed

----------------

### TESTS BY REVIEWERS
* [ ] Added to the automatic SW tests
* [x] Tested manually

