### PR TITLE
Add variables to the terminal autocompletion

### DIFF
--- a/changes.tmp
+++ b/changes.tmp
@@ -13,3 +13,4 @@ Fixed	The autoconversion of tables does not prefer logical over value columns an
 Cleaned	Improved the rendering speed of the terminal (relevant for larger strings, which required a bunch of virtual line breaks).
 Added	The functions "to_utf8()" and "to_ansi()" can be used to convert to and from UTF-8 encoded strings.
 Added	Folding has been enabled for LaTeX files.
+Added	The terminal now also proposed global variables for auto completion.

--- a/gui/editor/editor.cpp
+++ b/gui/editor/editor.cpp
@@ -6448,24 +6448,7 @@ bool NumeReEditor::isValidAutoCompMatch(int nPos, bool findAll, bool searchMetho
 /////////////////////////////////////////////////
 wxString NumeReEditor::generateAutoCompList(int wordstartpos, int currpos, std::string sPreDefList)
 {
-    std::map<wxString, int> mAutoCompMap;
-    wxString wReturn = "";
-    std::string sCurrentWord;
-
-    // Store the list of predefined values in the map
-    if (sPreDefList.length())
-    {
-        while (sPreDefList.length())
-        {
-            sCurrentWord = sPreDefList.substr(0, sPreDefList.find(' '));
-            mAutoCompMap[toUpperCase(sCurrentWord.substr(0, sCurrentWord.find_first_of("(?"))) + " |" + sCurrentWord] = -1;
-            sPreDefList.erase(0, sPreDefList.find(' '));
-
-            if (sPreDefList.front() == ' ')
-                sPreDefList.erase(0, 1);
-        }
-    }
-
+    std::string sScopedList;
     bool useSmartSense = m_options->getSetting(SETTING_B_SMARTSENSE).active();
     bool searchMethod = GetCharAt(wordstartpos) == '.';
     wxString wordstart = GetTextRange(searchMethod ? wordstartpos+1 : wordstartpos, currpos);
@@ -6495,8 +6478,8 @@ wxString NumeReEditor::generateAutoCompList(int wordstartpos, int currpos, std::
     {
         if (isValidAutoCompMatch(nPos, findAll, searchMethod))
         {
-            wxString sMatch = GetTextRange(nPos, WordEndPosition(nPos + 1, true));
-            wxString sFillUp;
+            std::string sMatch = GetTextRange(nPos, WordEndPosition(nPos + 1, true)).ToStdString();
+            std::string sFillUp;
 
             // Append the needed opening parentheses, if the completed
             // objects are data objects or functions
@@ -6507,7 +6490,7 @@ wxString NumeReEditor::generateAutoCompList(int wordstartpos, int currpos, std::
             else if (isStyleType(STYLE_IDENTIFIER, nPos))
                 sFillUp = "?" + toString((int)NumeReSyntax::SYNTAX_STD);
 
-            mAutoCompMap[toUpperCase(sMatch.ToStdString()) + " |" + sMatch+sFillUp] = 1;
+            sScopedList += sMatch + sFillUp + " ";
         }
 
         nPos++;
@@ -6529,8 +6512,8 @@ wxString NumeReEditor::generateAutoCompList(int wordstartpos, int currpos, std::
             {
                 if (isValidAutoCompMatch(pos, findAll, searchMethod))
                 {
-                    wxString sMatch = GetTextRange(pos, WordEndPosition(pos + 1, true));
-                    wxString sFillUp;
+                    std::string sMatch = GetTextRange(pos, WordEndPosition(pos + 1, true)).ToStdString();
+                    std::string sFillUp;
 
                     // Append the needed opening parentheses, if the completed
                     // objects are data objects or functions
@@ -6541,7 +6524,7 @@ wxString NumeReEditor::generateAutoCompList(int wordstartpos, int currpos, std::
                     else if (isStyleType(STYLE_IDENTIFIER, pos))
                         sFillUp = "?" + toString((int)NumeReSyntax::SYNTAX_STD);
 
-                    mAutoCompMap[toUpperCase(sMatch.ToStdString()) + " |" + sMatch+sFillUp] = 1;
+                    sScopedList += sMatch + sFillUp + " ";
                 }
 
                 pos++;
@@ -6549,35 +6532,8 @@ wxString NumeReEditor::generateAutoCompList(int wordstartpos, int currpos, std::
         }
     }
 
-    // remove duplicates
-    for (auto iter = mAutoCompMap.begin(); iter != mAutoCompMap.end(); ++iter)
-    {
-        if (iter->second == -1)
-        {
-            if ((iter->first).find('(') != std::string::npos)
-            {
-                if (mAutoCompMap.find((iter->first).substr(0, (iter->first).find('('))) != mAutoCompMap.end())
-                {
-                    mAutoCompMap.erase((iter->first).substr(0, (iter->first).find('(')));
-                    iter = mAutoCompMap.begin();
-                }
-            }
-            else
-            {
-                if (mAutoCompMap.find((iter->first).substr(0, (iter->first).find('?'))) != mAutoCompMap.end())
-                {
-                    mAutoCompMap.erase((iter->first).substr(0, (iter->first).find('?')));
-                    iter = mAutoCompMap.begin();
-                }
-            }
-        }
-    }
-
-    // Re-combine the autocompletion list
-    for (const auto& iter : mAutoCompMap)
-        wReturn += iter.first.substr(iter.first.find('|') + 1) + " ";
-
-    return wReturn;
+    // Use the static member function from NumeReSyntax to combine those two lists
+    return NumeReSyntax::mergeAutoCompleteLists(sPreDefList, sScopedList);
 }
 
 

--- a/gui/terminal/actions.cpp
+++ b/gui/terminal/actions.cpp
@@ -243,7 +243,7 @@ void GenericTerminal::tab()
                                                     get_method_root_type(nTabStartPos - (int)sAutoCompWordStart.length()-1, termCursor.y));
         }
         else
-            sAutoCompList = _syntax.getAutoCompList(sAutoCompWordStart, m_useSmartSense);
+            sAutoCompList = generateAutoCompList(sAutoCompWordStart, _syntax.getAutoCompList(sAutoCompWordStart, m_useSmartSense));
 
         // Reset the autocompletion, if no completion was found or the word start is too short
         if (!sAutoCompList.length() || (!sAutoCompWordStart.length() && !isMethod))
@@ -267,7 +267,7 @@ void GenericTerminal::tab()
                 sAutoCompList = _syntax.getAutoCompList("." + sAutoCompWordStart, m_useSmartSense,
                                                         get_method_root_type(nTabStartPos - (int)sAutoCompWordStart.length()-1, termCursor.y));
             else
-                sAutoCompList = _syntax.getAutoCompList(sAutoCompWordStart, m_useSmartSense);
+                sAutoCompList = generateAutoCompList(sAutoCompWordStart, _syntax.getAutoCompList(sAutoCompWordStart, m_useSmartSense));
         }
     }
 

--- a/gui/terminal/gterm.hpp
+++ b/gui/terminal/gterm.hpp
@@ -121,6 +121,7 @@ class GenericTerminal
         void cr(), lf(), ff(), bell(), tab();
         bool bs(), del();
         bool delSelected();
+        virtual std::string generateAutoCompList(const std::string& sWordStart, std::string sPreDefList) {return sPreDefList;}
 
         // escape sequence actions
         void reset();

--- a/gui/terminal/terminal.cpp
+++ b/gui/terminal/terminal.cpp
@@ -901,22 +901,7 @@ NumeReTerminal::SetCursorBlinkRate(int rate)
 std::string NumeReTerminal::generateAutoCompList(const std::string& sWordStart, std::string sPreDefList)
 {
     NumeReVariables globalVars = getVariableList();
-    std::map<std::string, int> mAutoCompMap;
-    std::string sCurrentWord;
-
-    // Store the list of predefined values in the map
-    if (sPreDefList.length())
-    {
-        while (sPreDefList.length())
-        {
-            sCurrentWord = sPreDefList.substr(0, sPreDefList.find(' '));
-            mAutoCompMap[toLowerCase(sCurrentWord.substr(0, sCurrentWord.find_first_of("(?"))) + " |" + sCurrentWord] = -1;
-            sPreDefList.erase(0, sPreDefList.find(' '));
-
-            if (sPreDefList.front() == ' ')
-                sPreDefList.erase(0, 1);
-        }
-    }
+    std::string sScopedList;
 
     // Now find all possible candidates
     for (std::string sVar : globalVars.vVariables)
@@ -926,43 +911,14 @@ std::string NumeReTerminal::generateAutoCompList(const std::string& sWordStart, 
         if (toLowerCase(sVar).substr(0, sWordStart.length()) == sWordStart)
         {
             if (sVar.find_first_of("({") != std::string::npos)
-                mAutoCompMap[sVar.substr(0, sVar.find_first_of("({")) + " |" + sVar.substr(0, sVar.find_first_of("({")+1) + "?1"] = 1;
+                sScopedList += sVar.substr(0, sVar.find_first_of("({")+1) + "?1 ";
             else
-                mAutoCompMap[sVar + " |" + sVar + "?1"] = 1;
+                sScopedList += sVar + "?1 ";
         }
     }
 
-    // remove duplicates
-    for (auto iter = mAutoCompMap.begin(); iter != mAutoCompMap.end(); ++iter)
-    {
-        if (iter->second == -1)
-        {
-            if ((iter->first).find('(') != std::string::npos)
-            {
-                if (mAutoCompMap.find((iter->first).substr(0, (iter->first).find('('))) != mAutoCompMap.end())
-                {
-                    mAutoCompMap.erase((iter->first).substr(0, (iter->first).find('(')));
-                    iter = mAutoCompMap.begin();
-                }
-            }
-            else
-            {
-                if (mAutoCompMap.find((iter->first).substr(0, (iter->first).find('?'))) != mAutoCompMap.end())
-                {
-                    mAutoCompMap.erase((iter->first).substr(0, (iter->first).find('?')));
-                    iter = mAutoCompMap.begin();
-                }
-            }
-        }
-    }
-
-    std::string sList;
-
-    // Re-combine the autocompletion list
-    for (const auto& iter : mAutoCompMap)
-        sList += iter.first.substr(iter.first.find('|') + 1) + " ";
-
-    return sList;
+    // Use the static member function from NumeReSyntax to combine those two lists
+    return NumeReSyntax::mergeAutoCompleteLists(sPreDefList, sScopedList);
 }
 
 

--- a/gui/terminal/terminal.cpp
+++ b/gui/terminal/terminal.cpp
@@ -889,6 +889,84 @@ NumeReTerminal::SetCursorBlinkRate(int rate)
 
 
 /////////////////////////////////////////////////
+/// \brief Generate the complete autocompletion
+/// list considering global variables as possible
+/// autocompletion candidates.
+///
+/// \param sWordStart const std::string&
+/// \param sPreDefList std::string
+/// \return std::string
+///
+/////////////////////////////////////////////////
+std::string NumeReTerminal::generateAutoCompList(const std::string& sWordStart, std::string sPreDefList)
+{
+    NumeReVariables globalVars = getVariableList();
+    std::map<std::string, int> mAutoCompMap;
+    std::string sCurrentWord;
+
+    // Store the list of predefined values in the map
+    if (sPreDefList.length())
+    {
+        while (sPreDefList.length())
+        {
+            sCurrentWord = sPreDefList.substr(0, sPreDefList.find(' '));
+            mAutoCompMap[toLowerCase(sCurrentWord.substr(0, sCurrentWord.find_first_of("(?"))) + " |" + sCurrentWord] = -1;
+            sPreDefList.erase(0, sPreDefList.find(' '));
+
+            if (sPreDefList.front() == ' ')
+                sPreDefList.erase(0, 1);
+        }
+    }
+
+    // Now find all possible candidates
+    for (std::string sVar : globalVars.vVariables)
+    {
+        sVar.erase(sVar.find('\t'));
+
+        if (toLowerCase(sVar).substr(0, sWordStart.length()) == sWordStart)
+        {
+            if (sVar.find_first_of("({") != std::string::npos)
+                mAutoCompMap[sVar.substr(0, sVar.find_first_of("({")) + " |" + sVar.substr(0, sVar.find_first_of("({")+1) + "?1"] = 1;
+            else
+                mAutoCompMap[sVar + " |" + sVar + "?1"] = 1;
+        }
+    }
+
+    // remove duplicates
+    for (auto iter = mAutoCompMap.begin(); iter != mAutoCompMap.end(); ++iter)
+    {
+        if (iter->second == -1)
+        {
+            if ((iter->first).find('(') != std::string::npos)
+            {
+                if (mAutoCompMap.find((iter->first).substr(0, (iter->first).find('('))) != mAutoCompMap.end())
+                {
+                    mAutoCompMap.erase((iter->first).substr(0, (iter->first).find('(')));
+                    iter = mAutoCompMap.begin();
+                }
+            }
+            else
+            {
+                if (mAutoCompMap.find((iter->first).substr(0, (iter->first).find('?'))) != mAutoCompMap.end())
+                {
+                    mAutoCompMap.erase((iter->first).substr(0, (iter->first).find('?')));
+                    iter = mAutoCompMap.begin();
+                }
+            }
+        }
+    }
+
+    std::string sList;
+
+    // Re-combine the autocompletion list
+    for (const auto& iter : mAutoCompMap)
+        sList += iter.first.substr(iter.first.find('|') + 1) + " ";
+
+    return sList;
+}
+
+
+/////////////////////////////////////////////////
 /// \brief Pass the entered command line to the
 /// kernel.
 ///

--- a/gui/terminal/terminal.hpp
+++ b/gui/terminal/terminal.hpp
@@ -133,6 +133,7 @@ class NumeReTerminal : public wxWindow, public GenericTerminal, public wxThreadH
 		}
 
 	private:
+		virtual std::string generateAutoCompList(const std::string& sWordStart, std::string sPreDefList) override;
 		void pipe_command(const std::string& sCommand);
 		BOLDSTYLE
 		m_boldStyle;

--- a/kernel/syntax.cpp
+++ b/kernel/syntax.cpp
@@ -201,6 +201,83 @@ void NumeReSyntax::setProcedureTree(const std::vector<std::string>& vTree)
 
 
 /////////////////////////////////////////////////
+/// \brief Merges the syntax-based predefined
+/// list with the scoped autocompletion list into
+/// a common autocompletion list.
+///
+/// \param sPreDefList std::string
+/// \param sScopedList std::string
+/// \return std::string
+///
+/////////////////////////////////////////////////
+std::string NumeReSyntax::mergeAutoCompleteLists(std::string sPreDefList, std::string sScopedList)
+{
+    std::map<std::string, int> mMergedMap;
+    std::string sCurrentWord;
+
+    // Store the list of predefined values in the map
+    if (sPreDefList.length())
+    {
+        while (sPreDefList.length())
+        {
+            sCurrentWord = sPreDefList.substr(0, sPreDefList.find(' '));
+            mMergedMap[toLowerCase(sCurrentWord.substr(0, sCurrentWord.find_first_of("({?"))) + " |" + sCurrentWord] = -1;
+            sPreDefList.erase(0, sPreDefList.find(' '));
+
+            if (sPreDefList.front() == ' ')
+                sPreDefList.erase(0, 1);
+        }
+    }
+
+    // Store the list of predefined values in the map
+    if (sScopedList.length())
+    {
+        while (sScopedList.length())
+        {
+            sCurrentWord = sScopedList.substr(0, sScopedList.find(' '));
+            mMergedMap[toLowerCase(sCurrentWord.substr(0, sCurrentWord.find_first_of("({?"))) + " |" + sCurrentWord] = 1;
+            sScopedList.erase(0, sScopedList.find(' '));
+
+            if (sScopedList.front() == ' ')
+                sScopedList.erase(0, 1);
+        }
+    }
+
+    // remove duplicates
+    for (auto iter = mMergedMap.begin(); iter != mMergedMap.end(); ++iter)
+    {
+        if (iter->second == -1)
+        {
+            if ((iter->first).find('(') != std::string::npos)
+            {
+                if (mMergedMap.find((iter->first).substr(0, (iter->first).find('('))) != mMergedMap.end())
+                {
+                    mMergedMap.erase((iter->first).substr(0, (iter->first).find('(')));
+                    iter = mMergedMap.begin();
+                }
+            }
+            else
+            {
+                if (mMergedMap.find((iter->first).substr(0, (iter->first).find('?'))) != mMergedMap.end())
+                {
+                    mMergedMap.erase((iter->first).substr(0, (iter->first).find('?')));
+                    iter = mMergedMap.begin();
+                }
+            }
+        }
+    }
+
+    std::string sList;
+
+    // Re-combine the autocompletion list
+    for (const auto& iter : mMergedMap)
+        sList += iter.first.substr(iter.first.find('|') + 1) + " ";
+
+    return sList;
+}
+
+
+/////////////////////////////////////////////////
 /// \brief Returns all block definitions as a
 /// folding string for the lexers.
 ///

--- a/kernel/syntax.hpp
+++ b/kernel/syntax.hpp
@@ -112,6 +112,9 @@ class NumeReSyntax
         void loadSyntax(const std::string& _sPath = "");
         void addPlugins(const std::vector<std::string>& vPlugins);
         void setProcedureTree(const std::vector<std::string>& vTree);
+
+        static std::string mergeAutoCompleteLists(std::string sPreDefList, std::string sScopedList);
+
         std::string getCommands() const
             {return constructString(vNSCRCommands);}
         std::string getNPRCCommands() const
@@ -154,5 +157,6 @@ class NumeReSyntax
             {return vBlockDefs;}
 
 };
+
 #endif // SYNTAX_HPP
 


### PR DESCRIPTION
### SUMMARY
Implements necessary changes for #98

*Reviewers:* @numere-org/maintainers

### IMPLEMENTATION
* Implementation: Added the virtual function as described.
* Implementation test: The terminal autocompletion now uses global variables as well. Tested that by creating some global variables.

### DOCUMENTATION
* [x] ChangesLog updated
* [x] Code changes commented
* **Documentation articles:**
    * [ ] corresponding documentation articles updated
    * [ ] new documentation articles created
    * [x] not needed
* **Language files:**
    * [ ] corresponding language files updated
    * [x] not needed

----------------

### TESTS BY REVIEWERS
* [ ] Added to the automatic SW tests
* [x] Tested manually

