### PR TITLE
Disabled the Diff creation for large files

### DIFF
--- a/changes.tmp
+++ b/changes.tmp
@@ -13,3 +13,4 @@ Fixed	The autoconversion of tables does not prefer logical over value columns an
 Cleaned	Improved the rendering speed of the terminal (relevant for larger strings, which required a bunch of virtual line breaks).
 Added	The functions "to_utf8()" and "to_ansi()" can be used to convert to and from UTF-8 encoded strings.
 Added	Folding has been enabled for LaTeX files.
+Applied	The revision of large files won't be created by calculating a DIFF. Instead, the whole file content is saved.

--- a/common/filerevisions.cpp
+++ b/common/filerevisions.cpp
@@ -770,6 +770,10 @@ size_t FileRevisions::addRevision(const wxString& revisionContent)
         if (revisionContent == getRevision(getCurrentRevision()))
             return -1;
 
+        // Do not calculate a DIFF of too large files
+        if (revContent.length() > 200000)
+            return createNewRevision(revContent, "");
+
         wxString diffFile = createDiff(revisionContent);
 
         if (diffFile.length() < getMaxDiffFileSize(revContent.length()))
@@ -802,8 +806,13 @@ size_t FileRevisions::addExternalRevision(const wxString& filePath)
     // Only add the external revision, if it actually
     // modified the file
     wxString currRev = getRevision(getCurrentRevision());
+
     if (currRev == revContent)
         return -1;
+
+    // Do not calculate a DIFF of too large files
+    if (revContent.length() > 200000)
+        return createNewRevision(convertLineEndings(revContent), "External modification");
 
     // Ensure that the diff is not actually empty
     if (!diff(currRev, "", revContent, "").length())

--- a/gui/editor/editor.cpp
+++ b/gui/editor/editor.cpp
@@ -408,6 +408,8 @@ bool NumeReEditor::SaveFile( const wxString& filename )
         m_simpleFileName = fn.GetFullName();
     }
 
+    bool createRevision = m_options->GetKeepBackupFile();
+
     VersionControlSystemManager manager(m_mainFrame);
     std::unique_ptr<FileRevisions> revisions;
 
@@ -415,9 +417,9 @@ bool NumeReEditor::SaveFile( const wxString& filename )
     if (filename.find("numere.history") == string::npos)
         revisions.reset(manager.getRevisions(filename));
 
-    if (revisions.get())
+    if (revisions)
     {
-        if (!revisions->getRevisionCount() && wxFileExists(filename))
+        if (!revisions->getRevisionCount() && wxFileExists(filename) && createRevision)
         {
             wxFile tempfile(filename);
             wxString contents;
@@ -447,7 +449,7 @@ bool NumeReEditor::SaveFile( const wxString& filename )
         // if the contents are not matching, restore the backup and signalize that an error occured
         if (wxFileExists(filename + ".backup"))
             wxCopyFile(filename + ".backup", filename, true);
-        else if (revisions.get() && revisions->getRevisionCount())
+        else if (revisions && revisions->getRevisionCount())
             revisions->restoreRevision(revisions->getRevisionCount()-1, filename);
 
         return false;
@@ -457,7 +459,7 @@ bool NumeReEditor::SaveFile( const wxString& filename )
         // if the contents are not matching, restore the backup and signalize that an error occured
         if (wxFileExists(filename + ".backup"))
             wxCopyFile(filename + ".backup", filename, true);
-        else if (revisions.get() && revisions->getRevisionCount())
+        else if (revisions && revisions->getRevisionCount())
             revisions->restoreRevision(revisions->getRevisionCount()-1, filename);
 
         return false;
@@ -467,7 +469,7 @@ bool NumeReEditor::SaveFile( const wxString& filename )
         // if the contents are not matching, restore the backup and signalize that an error occured
         if (wxFileExists(filename + ".backup"))
             wxCopyFile(filename + ".backup", filename, true);
-        else if (revisions.get() && revisions->getRevisionCount())
+        else if (revisions && revisions->getRevisionCount())
             revisions->restoreRevision(revisions->getRevisionCount()-1, filename);
 
         return false;
@@ -475,7 +477,7 @@ bool NumeReEditor::SaveFile( const wxString& filename )
 
     // Add the current text to the revisions, if the saving process was
     // successful
-    if (revisions.get() && m_options->GetKeepBackupFile())
+    if (revisions && createRevision)
         revisions->addRevision(GetText());
 
     // If the user doesn't want to keep the backup files


### PR DESCRIPTION
### SUMMARY
Implements necessary changes for #83

*Reviewers:* @numere-org/maintainers

### IMPLEMENTATION
* Implementation: Disabled the DIFF creation of large files (Files with more than 200 KB). The file's contents are stored completely instead
* Implementation test: Modified a small and a larger file. Saving time has been reduced greatly, the bypass condition was used as expected.

### DOCUMENTATION
* [x] ChangesLog updated
* [x] Code changes commented
* **Documentation articles:**
    * [ ] corresponding documentation articles updated
    * [ ] new documentation articles created
    * [x] not needed
* **Language files:**
    * [ ] corresponding language files updated
    * [x] not needed

----------------

### TESTS BY REVIEWERS
* [ ] Added to the automatic SW tests
* [x] Tested manually

