### PR TITLE
Closing print preview of documentation browser results in a crash

### DIFF
--- a/changes.tmp
+++ b/changes.tmp
@@ -15,4 +15,4 @@ Added	The functions "to_utf8()" and "to_ansi()" can be used to convert to and fr
 Added	Folding has been enabled for LaTeX files.
 Added	The terminal now also proposed global variables for auto completion.
 Applied	The revision of large files won't be created by calculating a DIFF. Instead, the whole file content is saved.
-Added   It is possible to directly access the first and last character of a string
+Fixed	NumeRe does not crash anymore after the print preview of the documentation browser has been closed.

--- a/gui/compositions/helpviewer.cpp
+++ b/gui/compositions/helpviewer.cpp
@@ -256,6 +256,24 @@ bool HelpViewer::GoIndex()
 
 
 /////////////////////////////////////////////////
+/// \brief Static helper function to create a
+/// basic printout object.
+///
+/// \return wxHtmlPrintout*
+///
+/////////////////////////////////////////////////
+static wxHtmlPrintout* createPrintout()
+{
+    wxHtmlPrintout* printout = new wxHtmlPrintout();
+    printout->SetFonts(wxEmptyString, "Consolas");
+    printout->SetMargins(12.6f, 12.6f, 12.6f, 12.6f, 2.5f);
+    printout->SetFooter("<div align=\"center\">@PAGENUM@ / @PAGESCNT@</div>");
+
+    return printout;
+}
+
+
+/////////////////////////////////////////////////
 /// \brief Public member function to open the
 /// print preview page.
 ///
@@ -273,10 +291,8 @@ bool HelpViewer::Print()
 
     // Create a new html printout class and apply the
     // necessary settings
-    wxHtmlPrintout* printout = new wxHtmlPrintout();
-    printout->SetFonts(wxEmptyString, "Consolas");
-    printout->SetMargins(12.6f, 12.6f, 12.6f, 12.6f, 2.5f);
-    printout->SetFooter("<div align=\"center\">@PAGENUM@ / @PAGESCNT@</div>");
+    wxHtmlPrintout* printout = createPrintout();
+    wxHtmlPrintout* printoutForPrinting = createPrintout();
 
     // Obtain the content of the page from the history
     wxString htmlText = vHistory[m_nHistoryPointer];
@@ -285,12 +301,18 @@ bool HelpViewer::Print()
     // assign it directly or obtain the page data from the
     // kernel
     if (htmlText.substr(0,15) == "<!DOCTYPE html>")
+    {
         printout->SetHtmlText(htmlText);
+        printoutForPrinting->SetHtmlText(htmlText);
+    }
     else
+    {
         printout->SetHtmlText(m_mainFrame->GetDocContent(htmlText));
+        printoutForPrinting->SetHtmlText(m_mainFrame->GetDocContent(htmlText));
+    }
 
     // Create a new preview object
-    wxPrintPreview *preview = new wxPrintPreview(printout, printout, g_printData);
+    wxPrintPreview *preview = new wxPrintPreview(printout, printoutForPrinting, g_printData);
 
     // Ensure that the preview is filled correctly
     if (!preview->Ok())


### PR DESCRIPTION
### SUMMARY
Implements necessary changes for #116

*Reviewers:* @numere-org/maintainers

### IMPLEMENTATION
* Implementation: Fixed the problem by introducing a secondary `wxHtmlPrintout` object.
* Implementation test: Some print previews of documentation browsers were created and closed without problems.

### DOCUMENTATION
* [x] ChangesLog updated
* [x] Code changes commented
* **Documentation articles:**
    * [ ] corresponding documentation articles updated
    * [ ] new documentation articles created
    * [x] not needed
* **Language files:**
    * [ ] corresponding language files updated
    * [x] not needed

----------------

### TESTS BY REVIEWERS
* [ ] Added to the automatic SW tests
* [x] Tested manually

