### PR TITLE
'hist' shall use categories, if available

### DIFF
--- a/changes.tmp
+++ b/changes.tmp
@@ -15,4 +15,4 @@ Added	The functions "to_utf8()" and "to_ansi()" can be used to convert to and fr
 Added	Folding has been enabled for LaTeX files.
 Added	The terminal now also proposed global variables for auto completion.
 Applied	The revision of large files won't be created by calculating a DIFF. Instead, the whole file content is saved.
-Added   It is possible to directly access the first and last character of a string
+Cleaned	"hist" will now use categories or logical values to determine the bins, however this only works, if all columns share their type and their category definitions. Otherwise abstract categories are defined.

--- a/kernel/kernel.cpp
+++ b/kernel/kernel.cpp
@@ -2871,7 +2871,7 @@ std::string NumeReKernel::formatResultOutput(const std::vector<std::string>& vSt
         // return the composed result
         return sAns;
     }
-    else
+    else if (vStringResults.size())
     {
         // Only one result
         // return the answer


### PR DESCRIPTION
### SUMMARY
Implements necessary changes for #26

*Reviewers:* @numere-org/maintainers

### IMPLEMENTATION
* Implementation: Implemented the usage of categories and logical values as described by the issue. Categories not representable by a common superset will be represented by abstract categories
* Implementation test: Tested single categorical and logical columns as well as a combination of multiple categories (not) representable as common superset. 

### DOCUMENTATION
* [x] ChangesLog updated
* [x] Code changes commented
* **Documentation articles:**
    * [ ] corresponding documentation articles updated
    * [ ] new documentation articles created
    * [x] not needed -- will be done with the changes required by #27 
* **Language files:**
    * [ ] corresponding language files updated
    * [x] not needed

----------------

### TESTS BY REVIEWERS
* [ ] Added to the automatic SW tests
* [ ] Tested manually

