### PR TITLE
[GLITCH] If window is minimized, double-clicking on script file won't scale the editor correctly

### DIFF
--- a/changes.tmp
+++ b/changes.tmp
@@ -15,4 +15,4 @@ Added	The functions "to_utf8()" and "to_ansi()" can be used to convert to and fr
 Added	Folding has been enabled for LaTeX files.
 Added	The terminal now also proposed global variables for auto completion.
 Applied	The revision of large files won't be created by calculating a DIFF. Instead, the whole file content is saved.
-Added   It is possible to directly access the first and last character of a string
+Fixed	NumeRe will now restore its window, if it is iconized and one double-clicks on any linked file to have the editor scaled correctly.

--- a/gui/NumeReWindow.cpp
+++ b/gui/NumeReWindow.cpp
@@ -3004,6 +3004,10 @@ void NumeReWindow::EvaluateCommandLine(wxArrayString& wxArgV)
     wxArrayString filestoopen;
     wxString ext;
 
+    // Only necessary, if there are more than one entries in the command line
+    if (wxArgV.size() > 1 && IsIconized())
+        Restore();
+
     for (size_t i = 1; i < wxArgV.size(); i++)
     {
         if (wxArgV[i].find('.') == std::string::npos)


### PR DESCRIPTION
### SUMMARY
Implements necessary changes for #41

*Reviewers:* @numere-org/maintainers

### IMPLEMENTATION
* Implementation: Added the automatic restore of the main window as indicated by the analysis.
* Implementation test: Tested both situations: app is iconized and one double-clicks on a linked file and app is closed and one starts it with the linked file. Both situations worked as expected.

### DOCUMENTATION
* [x] ChangesLog updated
* [x] Code changes commented
* **Documentation articles:**
    * [ ] corresponding documentation articles updated
    * [ ] new documentation articles created
    * [x] not needed
* **Language files:**
    * [ ] corresponding language files updated
    * [x] not needed

----------------

### TESTS BY REVIEWERS
* [ ] Added to the automatic SW tests
* [x] Tested manually

