### PR TITLE
Convert documentation files to UTF-8

### DIFF
--- a/changes.tmp
+++ b/changes.tmp
@@ -15,4 +15,4 @@ Added	The functions "to_utf8()" and "to_ansi()" can be used to convert to and fr
 Added	Folding has been enabled for LaTeX files.
 Added	The terminal now also proposed global variables for auto completion.
 Applied	The revision of large files won't be created by calculating a DIFF. Instead, the whole file content is saved.
-Added   It is possible to directly access the first and last character of a string
+Updated	Language files and documentation articles may now be encoded using UTF-8. They're converted to CP1252 internally.

--- a/kernel/core/datamanagement/database.cpp
+++ b/kernel/core/datamanagement/database.cpp
@@ -59,7 +59,7 @@ namespace NumeRe
             {
                 if (sLine[0] == '#')
                     continue;
-                vDBEntries.push_back(sLine);
+                vDBEntries.push_back(utf8parser(sLine));
             }
         }
 

--- a/kernel/core/documentation/doc_helper.cpp
+++ b/kernel/core/documentation/doc_helper.cpp
@@ -163,7 +163,7 @@ static std::vector<std::string> loadDocumentationArticle(const std::string& sFil
         // Extract the title
         if (sLine.find("<title ") != std::string::npos)
         {
-            vReturn.push_back(getArgAtPos(sLine, sLine.find("string=", sLine.find("<title "))+7));
+            vReturn.push_back(utf8parser(getArgAtPos(sLine, sLine.find("string=", sLine.find("<title "))+7)));
             sLine.erase(0, sLine.find("/>", sLine.find("<title "))+2);
             StripSpaces(sLine);
 
@@ -177,7 +177,7 @@ static std::vector<std::string> loadDocumentationArticle(const std::string& sFil
             sLine.erase(0, sLine.find("<contents>")+10);
 
             if (sLine.length())
-                vReturn.push_back(sLine);
+                vReturn.push_back(utf8parser(sLine));
 
             while (!fDocument.eof())
             {
@@ -195,12 +195,12 @@ static std::vector<std::string> loadDocumentationArticle(const std::string& sFil
                     sLine.erase(sLine.find("</contents>"));
 
                     if (sLine.length())
-                        vReturn.push_back(sLine);
+                        vReturn.push_back(utf8parser(sLine));
 
                     return vReturn;
                 }
 
-                vReturn.push_back(sLine);
+                vReturn.push_back(utf8parser(sLine));
             }
         }
     }

--- a/kernel/core/documentation/docfile.cpp
+++ b/kernel/core/documentation/docfile.cpp
@@ -55,7 +55,7 @@ static void parseHeader(const std::string& sCombinedArticle, DocumentationEntry&
 
     // Get title and IDX keys
     if (iter && iter->Attribute("string"))
-        docEntry.sTitle = iter->Attribute("string");
+        docEntry.sTitle = utf8ToAnsi(iter->Attribute("string"));
 
     if (iter && iter->Attribute("idxkey"))
         docEntry.sIdxKeys = iter->Attribute("idxkey");
@@ -199,7 +199,7 @@ static int indentationLevelDiff(const std::string& sText)
 std::string DocumentationArticle::format()
 {
     // Format the header
-    std::string sFormat = "<article id=\"" + m_docEntry.sArticleId + "\" >\n\t<title string=\"" + m_docEntry.sTitle + "\" idxkey=\"" + m_docEntry.sIdxKeys + "\" />\n\t<keywords>\n";
+    std::string sFormat = "<article id=\"" + m_docEntry.sArticleId + "\" >\n\t<title string=\"" + ansiToUtf8(m_docEntry.sTitle) + "\" idxkey=\"" + m_docEntry.sIdxKeys + "\" />\n\t<keywords>\n";
 
     // Add the keywords
     for (const auto& keyw : m_keywords)
@@ -225,7 +225,7 @@ std::string DocumentationArticle::format()
         indentationLevel = std::max(0, indentationLevel);
 
         sFormat.append(indentationLevel+2, '\t');
-        sFormat += text + "\n";
+        sFormat += ansiToUtf8(text) + "\n";
 
         if (indLevelDiff > 0)
             indentationLevel += indLevelDiff;

--- a/kernel/core/documentation/documentation.cpp
+++ b/kernel/core/documentation/documentation.cpp
@@ -345,6 +345,14 @@ static void doc_splitDocumentation(const std::string& sDefinition, std::vector<s
 }
 
 
+/////////////////////////////////////////////////
+/// \brief Extract the argument list of the
+/// passed function definition.
+///
+/// \param sDefinition std::string
+/// \return std::vector<std::string>
+///
+/////////////////////////////////////////////////
 static std::vector<std::string> getArgumentList(std::string sDefinition)
 {
     size_t pos = sDefinition.find('(');
@@ -362,6 +370,45 @@ static std::vector<std::string> getArgumentList(std::string sDefinition)
 }
 
 
+/////////////////////////////////////////////////
+/// \brief Replaces the occurences of a single
+/// argument in a single string with their code
+/// highlighted variant.
+///
+/// \param sArgument const std::string&
+/// \param sString std::string&
+/// \param nPos size_t
+/// \return void
+///
+/////////////////////////////////////////////////
+static void replaceArgumentOccurences(const std::string& sArgument, std::string& sString, size_t nPos)
+{
+    // Search for the next occurence of the variable
+    while ((nPos = sString.find(sArgument, nPos)) != std::string::npos)
+    {
+        // check, whether the found match is an actual variable
+        if (checkDelimiter(sString.substr(nPos-1, sArgument.length() + 2)))
+        {
+            // replace VAR with <code>VAR</code> and increment the
+            // position index by the variable length + 13
+            sString.replace(nPos, sArgument.length(), "<code>" + sArgument + "</code>");
+            nPos += sArgument.length() + 13;
+        }
+        else
+            nPos += sArgument.length();
+    }
+}
+
+
+/////////////////////////////////////////////////
+/// \brief Apply a code style to the arguments of
+/// the function used within the description.
+///
+/// \param vDoc std::vector<std::string>&
+/// \param sDefinition const std::string&
+/// \return void
+///
+/////////////////////////////////////////////////
 static void applyCodeHighlighting(std::vector<std::string>& vDoc, const std::string& sDefinition)
 {
     std::vector<std::string> vArgs = getArgumentList(sDefinition);
@@ -383,10 +430,8 @@ static void applyCodeHighlighting(std::vector<std::string>& vDoc, const std::str
             if (vDoc[i].substr(0, 6) == "<item ")
                 startPos = vDoc[i].find("\">")+2;
 
-            replaceAll(vDoc[i],
-                       arg,
-                       "<code>" + arg + "</code>",
-                       startPos);
+            replaceArgumentOccurences(arg, vDoc[i], startPos);
+            replaceArgumentOccurences("_" + arg, vDoc[i], startPos);
         }
     }
 }

--- a/kernel/core/ui/language.cpp
+++ b/kernel/core/ui/language.cpp
@@ -89,6 +89,9 @@ map<string,string> Language::getLangFileContent(const string& sFile) const
         if (sLine.front() == '#')
             continue;
 
+        // Convert UTF-8 encoded text to CP1252
+        sLine = utf8ToAnsi(sLine);
+
         // Replace included tab characters with
         // whitespaces
         for (size_t i = 0; i < sLine.length(); i++)


### PR DESCRIPTION
### SUMMARY
Implements necessary changes for #97

*Reviewers:* @numere-org/maintainers

### IMPLEMENTATION
* Implementation: Implemented as proposed by the analysis.
* Implementation test: Converted all german language files to UTF-8 and started the appliction. No typical UTF-8 character combinations were visible

### DOCUMENTATION
* [x] ChangesLog updated
* [x] Code changes commented
* **Documentation articles:**
    * [x] corresponding documentation articles updated
    * [ ] new documentation articles created
    * [ ] not needed
* **Language files:**
    * [x] corresponding language files updated
    * [ ] not needed

----------------

### TESTS BY REVIEWERS
* [ ] Added to the automatic SW tests
* [x] Tested manually

