### PR TITLE
XLS sheet labels too long

### DIFF
--- a/changes.tmp
+++ b/changes.tmp
@@ -20,4 +20,4 @@ Added	String functions to compare the first and last characters of a string to a
 Fixed	NumeRe will now restore its window, if it is iconized and one double-clicks on any linked file to have the editor scaled correctly.
 Fixed	NumeRe does not crash anymore after the print preview of the documentation browser has been closed.
 Updated	Language files and documentation articles may now be encoded using UTF-8. They're converted to CP1252 internally.
-
+Fixed	If the table name is now longer than 31 characters, an automatic sheet name will be used in XLS exports.

--- a/kernel/core/io/file.cpp
+++ b/kernel/core/io/file.cpp
@@ -3814,6 +3814,9 @@ namespace NumeRe
         string sHeadLine;
         string sSheetName = getTableName();
 
+        if (sSheetName.length() > MAXSHEETLENGTH)
+            sSheetName = "Table";
+
         // Create a new sheet
         _excel.New(1);
 

--- a/kernel/core/io/file.hpp
+++ b/kernel/core/io/file.hpp
@@ -1819,6 +1819,7 @@ namespace NumeRe
     class XLSSpreadSheet : public GenericFile
     {
         private:
+            const size_t MAXSHEETLENGTH = 31;
             void readFile();
             void writeFile();
 


### PR DESCRIPTION
### SUMMARY
Implements necessary changes for #136

*Reviewers:* @numere-org/maintainers

### IMPLEMENTATION
* Implementation: Table names longer than 31 characters will now be replaced by `"Table"`
* Implementation test: Executed file IO tests without problems.

### DOCUMENTATION
* [x] ChangesLog updated
* [x] Code changes commented
* **Documentation articles:**
    * [ ] corresponding documentation articles updated
    * [ ] new documentation articles created
    * [x] not needed
* **Language files:**
    * [ ] corresponding language files updated
    * [x] not needed

----------------

### TESTS BY REVIEWERS
* [ ] Added to the automatic SW tests
* [x] Tested manually

